### PR TITLE
[UDU-4] Added a the PrerequisitesContainer model.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ucronmodels
-version = 0.0.2
+version = 0.0.3
 keywords = ucron, models, package
 
 [options]

--- a/ucronmodels/drexel/enums/headers.py
+++ b/ucronmodels/drexel/enums/headers.py
@@ -30,7 +30,7 @@ class SectionHeaders(Enum):
     TEXTBOOKS = "Textbooks"
 
 
-class AddtionalDetailsHeaders(Enum):
+class AdditionalDetailsHeaders(Enum):
     COURSE_DESCRIPTION = "Course Description:"
     CREDITS = "Credits:"
     COLLEGE = "College:"

--- a/ucronmodels/drexel/models/prerequisites_container.py
+++ b/ucronmodels/drexel/models/prerequisites_container.py
@@ -1,0 +1,41 @@
+from typing import Optional
+
+from pydantic.alias_generators import to_camel
+
+from .prerequisites import Prerequisites
+
+
+class PrerequisitesContainer:
+    """
+    A model that will be used to transport prerequisites information for a course.
+    """
+
+    subject_code: str
+    """
+    The subject code of the course, such as "CS" for Computer Science.
+    """
+
+    course_number: str
+    """
+    The course number, which is a unique identifier for the course within its subject code.
+    """
+
+    prerequisites: Optional[Prerequisites]
+    """
+    Prerequisite courses for this course, if any.
+    """
+
+    class Config:
+        """
+        Configuration class for `MongoDBModel` model.
+        """
+
+        alias_generator = to_camel
+        """
+        A function that is used to generate aliases for model fields.
+        """
+
+        populate_by_name = True
+        """
+        Whether an aliased field may be populated by its name as given by the model attribute, as well as the alias.
+        """


### PR DESCRIPTION
## Description

The Butler API needs two new endpoints: one that returns prerequisite detail about a course; two that returns all prerequisite details for all courses for a given subject code. This will we used when creating dependency graphs.

A new model needs to be created that will contain all the prerequisites details for multiple courses. Alternatively, the BaseCourse model can be updated to support partial specification, will allow us to use a collection of BaseCourse object to transport only required information.

---

## Acceptance Criteria

- [ ]  There should be a `GET` endpoint to retrieve prerequisites detail for a course given the subject code and course number.
- [x]  Create a new model `PrerequisitesContainer` that will contain the *subject code, course number* and the *prerequisites*.
- [ ]  There should be another `GET` endpoint to retrieve prerequisite details for all courses for a given subject code.