### PR TITLE
[UDU-14] Updated the PyObjectId type. Added the INVALID value in the DatabaseW…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,20 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-line-length = 99
+line-length = 102
+exclude = '''
+/(
+    \.git
+  | \.mypy_cache
+  | \.tox
+  | venv
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''
 
 [tool.isort]
 profile = "black"
-line_length = 99

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,4 @@ exclude = '''
 
 [tool.isort]
 profile = "black"
+line_length = 102

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
 annotated-types==0.6.0
 anyio==3.7.1
+bson==0.5.10
 fastapi==0.105.0
 graphql-core==3.2.3
 idna==3.6
+mypy==1.8.0
+mypy-extensions==1.0.0
 pydantic==2.5.3
 pydantic_core==2.14.6
 python-dateutil==2.8.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ucronmodels
-version = 0.0.13
+version = 0.0.14
 keywords = ucron, models, package
 
 [options]

--- a/ucronmodels/universal/enums/database_write_operation.py
+++ b/ucronmodels/universal/enums/database_write_operation.py
@@ -20,3 +20,8 @@ class DatabaseWriteOperation(StrEnum):
     """
     DELETE: Represents a delete operation.
     """
+
+    INVALID = "INVALID"
+    """
+    INVALID: Represents an invalid operation.
+    """

--- a/ucronmodels/universal/models/pyobjectid.py
+++ b/ucronmodels/universal/models/pyobjectid.py
@@ -1,5 +1,60 @@
-from typing import Annotated
+from typing import Any
 
-from pydantic import BeforeValidator
+from bson import ObjectId
+from pydantic_core import core_schema
 
-PyObjectId = Annotated[str, BeforeValidator(str)]
+
+class PyObjectId(str):
+    """
+    Custom class for representing a Pydantic model field as a MongoDB ObjectId.
+
+    This class inherits from `str` and provides methods for validating and serializing
+    ObjectIds in Pydantic models.
+    """
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, _source_type: Any, _handler: Any) -> core_schema.CoreSchema:
+        """
+        Returns the Pydantic core schema for this custom ObjectId field.
+
+        Args:
+            _source_type (Any): The source type of the field, unused in this implementation.
+            _handler (Any): The handler for the field, unused in this implementation.
+
+        Returns:
+            core_schema.CoreSchema: The core schema for validating and serializing ObjectIds.
+        """
+        return core_schema.json_or_python_schema(
+            json_schema=core_schema.str_schema(),
+            python_schema=core_schema.union_schema(
+                [
+                    core_schema.is_instance_schema(ObjectId),
+                    core_schema.chain_schema(
+                        [
+                            core_schema.str_schema(),
+                            core_schema.no_info_plain_validator_function(cls.validate),
+                        ]
+                    ),
+                ]
+            ),
+            serialization=core_schema.plain_serializer_function_ser_schema(lambda x: str(x)),
+        )
+
+    @classmethod
+    def validate(cls, value: str) -> ObjectId:
+        """
+        Validates that the given string is a valid ObjectId.
+
+        Args:
+            value (str): The string to validate as an ObjectId.
+
+        Returns:
+            ObjectId: The validated ObjectId.
+
+        Raises:
+            ValueError: If the string is not a valid ObjectId.
+        """
+        if not ObjectId.is_valid(value):
+            raise ValueError("Invalid ObjectId")
+
+        return ObjectId(value)


### PR DESCRIPTION
# Changes

- The `DatabaseWriteOperation` enum class has a new value: `INVALID` that represents an invalid database operation. This is intended to notify users that they are trying to perform invalid operations.
- The `PyObjectId` type is now a class instead of just a type annotation. This change allows us to validate the provided ObjectID string.