### PR TITLE
[UDU-51] Models to support course search

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ucronmodels
-version = 0.0.15
+version = 0.0.16
 keywords = ucron, models, package
 
 [options]

--- a/ucronmodels/drexel/models/client/__init__.py
+++ b/ucronmodels/drexel/models/client/__init__.py
@@ -1,0 +1,2 @@
+from .course_client import CourseClient
+from .section_client import SectionClient

--- a/ucronmodels/drexel/models/client/course_client.py
+++ b/ucronmodels/drexel/models/client/course_client.py
@@ -1,7 +1,7 @@
 from typing import List
 
-from ucronmodels.drexel.models.database import CourseDB
-from ucronmodels.drexel.models.client.section_client import SectionClient
+from ..database import CourseDB
+from .section_client import SectionClient
 
 
 class CourseClient(CourseDB):

--- a/ucronmodels/drexel/models/client/course_client.py
+++ b/ucronmodels/drexel/models/client/course_client.py
@@ -1,0 +1,13 @@
+from typing import List
+
+from ucronmodels.drexel.models.database import CourseDB
+from ucronmodels.drexel.models.client.section_client import SectionClient
+
+
+class CourseClient(CourseDB):
+    """
+    This model extends the CourseDB model and contains a list of associated section client models.
+    """
+
+    sections: List[SectionClient]
+    """The list of sections."""

--- a/ucronmodels/drexel/models/client/section_client.py
+++ b/ucronmodels/drexel/models/client/section_client.py
@@ -1,5 +1,6 @@
 from typing import List
-from ucronmodels.drexel.models.database import SectionDB, InstructorDB
+
+from ..database import InstructorDB, SectionDB
 
 
 class SectionClient(SectionDB):

--- a/ucronmodels/drexel/models/client/section_client.py
+++ b/ucronmodels/drexel/models/client/section_client.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Sequence
 
 from ..database import InstructorDB, SectionDB
 
@@ -8,5 +8,5 @@ class SectionClient(SectionDB):
     This model extends the SectionDB model and contains a list of instructor models.
     """
 
-    instructors: List[InstructorDB]
+    instructors: Sequence[InstructorDB]
     """The list of instructors teaching the course section."""

--- a/ucronmodels/drexel/models/client/section_client.py
+++ b/ucronmodels/drexel/models/client/section_client.py
@@ -1,0 +1,11 @@
+from typing import List
+from ucronmodels.drexel.models.database import SectionDB, InstructorDB
+
+
+class SectionClient(SectionDB):
+    """
+    This model extends the SectionDB model and contains a list of instructor models.
+    """
+
+    instructors: List[InstructorDB]
+    """The list of instructors teaching the course section."""

--- a/ucronmodels/drexel/models/common/schedule.py
+++ b/ucronmodels/drexel/models/common/schedule.py
@@ -66,8 +66,7 @@ class CourseSchedule(BaseModel):
         """
         if isinstance(start_date, str):
             try:
-                date = datetime.strptime(start_date, "%Y-%m-%dT%H:%M:%S%z")
-                return date
+                return datetime.strptime(start_date, "%Y-%m-%dT%H:%M:%S%z")
             except ValueError:
                 pass
         return start_date
@@ -85,8 +84,7 @@ class CourseSchedule(BaseModel):
         """
         if isinstance(end_date, str):
             try:
-                date = datetime.strptime(end_date, "%Y-%m-%dT%H:%M:%S%z")
-                return date
+                return datetime.strptime(end_date, "%Y-%m-%dT%H:%M:%S%z")
             except ValueError:
                 pass
         return end_date

--- a/ucronmodels/drexel/models/common/schedule.py
+++ b/ucronmodels/drexel/models/common/schedule.py
@@ -1,7 +1,7 @@
-from datetime import datetime
+from datetime import datetime, time
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
 from pydantic.alias_generators import to_camel
 
 from ucronmodels.universal.enums import DaySymbol
@@ -12,15 +12,11 @@ class TimeRange(BaseModel):
     Represents a time range with a start and end time.
     """
 
-    start_time: str
-    """
-    The starting time of the range, represented as a string.
-    """
+    start_time: time | str
+    """The starting time of the range."""
 
-    end_time: str
-    """
-    The ending time of the range, represented as a string.
-    """
+    end_time: time | str
+    """The ending time of the range."""
 
     class Config:
         """
@@ -28,14 +24,10 @@ class TimeRange(BaseModel):
         """
 
         alias_generator = to_camel
-        """
-        A function that is used to generate aliases for model fields.
-        """
+        """A function that is used to generate aliases for model fields."""
 
         populate_by_name = True
-        """
-        Whether an aliased field may be populated by its name as given by the model attribute, as well as the alias.
-        """
+        """Whether an aliased field may be populated by its name as given by the model attribute, as well as the alias."""
 
 
 class CourseSchedule(BaseModel):
@@ -44,34 +36,60 @@ class CourseSchedule(BaseModel):
     """
 
     start_date: Optional[datetime | str] = None
-    """
-    The start date of the course.
-    """
+    """The start date of the course."""
 
     end_date: Optional[datetime | str] = None
-    """
-    The end date of the course.
-    """
+    """The end date of the course."""
 
     time: TimeRange | str
-    """
-    The time range for the course.
-    """
+    """The time range for the course."""
 
     days: List[DaySymbol]
-    """
-    The days when the course will be held.
-    """
+    """The days when the course will be held."""
 
     building: str
-    """
-    The building where the course will be conducted.
-    """
+    """The building where the course will be conducted."""
 
     room: str
-    """
-    The room number or name where the course will take place.
-    """
+    """The room number or name where the course will take place."""
+
+    @field_serializer("start_date", when_used="always")
+    def serialize_start_date(start_date: Optional[datetime | str]) -> Optional[datetime | str]:
+        """
+        Field serializer for the `start_date` field.
+
+        Args:
+            start_date (Optional[datetime | str]): The start date of the course.
+
+        Returns:
+            Optional[datetime | str]: The serialized start date.
+        """
+        if isinstance(start_date, str):
+            try:
+                date = datetime.strptime(start_date, "%Y-%m-%dT%H:%M:%S%z")
+                return date
+            except ValueError:
+                pass
+        return start_date
+
+    @field_serializer("end_date", when_used="always")
+    def serialize_end_date(end_date: Optional[datetime | str]) -> Optional[datetime | str]:
+        """
+        Field serializer for the `end_date` field.
+
+        Args:
+            end_date (Optional[datetime | str]): The end date of the course.
+
+        Returns:
+            Optional[datetime | str]: The serialized start date.
+        """
+        if isinstance(end_date, str):
+            try:
+                date = datetime.strptime(end_date, "%Y-%m-%dT%H:%M:%S%z")
+                return date
+            except ValueError:
+                pass
+        return end_date
 
     class Config:
         """
@@ -79,16 +97,10 @@ class CourseSchedule(BaseModel):
         """
 
         alias_generator = to_camel
-        """
-        A function that is used to generate aliases for model fields.
-        """
+        """A function that is used to generate aliases for model fields."""
 
         populate_by_name = True
-        """
-        Whether an aliased field may be populated by its name as given by the model attribute, as well as the alias.
-        """
+        """Whether an aliased field may be populated by its name as given by the model attribute, as well as the alias."""
 
         use_enum_values = True
-        """
-        Indicates whether to use the enum values themselves instead of the enum instances.
-        """
+        """Indicates whether to use the enum values themselves instead of the enum instances."""

--- a/ucronmodels/drexel/models/database/section.py
+++ b/ucronmodels/drexel/models/database/section.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional, Sequence
 
 from pydantic.alias_generators import to_camel
 
@@ -13,74 +13,46 @@ class SectionDB(MongoDBModel):
     """
 
     subject_code: str
-    """
-    The subject code of the course, such as "CS" for Computer Science.
-    """
+    """The subject code of the course, such as "CS" for Computer Science."""
 
     course_number: str
-    """
-    The course number, which is a unique identifier for the course within its subject code.
-    """
+    """The course number, which is a unique identifier for the course within its subject code."""
 
     section: str
-    """
-    The section identifier for the course, e.g., "001" or "A01."
-    """
+    """The section identifier for the course, e.g., "001" or "A01"."""
 
     term_code: int
-    """
-    The code that represents the term the course is offered in.
-    """
+    """The code that represents the term the course is offered in."""
 
     crn: int
-    """
-    The Course Reference Number (CRN) associated with this course section.
-    """
+    """The Course Reference Number (CRN) associated with this course section."""
 
     credits: Optional["Credits"] = None
-    """
-    Number of possible credits for a Course Section.
-    """
+    """Number of possible credits for a Course Section."""
 
     instruction_type: str
-    """
-    The type of instruction for the course section, such as "Lecture" or "Lab."
-    """
+    """The type of instruction for the course section, such as "Lecture" or "Lab"."""
 
     instruction_method: str
-    """
-    The method of instruction for the course section, such as "In-Person" or "Online."
-    """
+    """The method of instruction for the course section, such as "In-Person" or "Online"."""
 
-    instructors: List[PyObjectId]
-    """
-    The list of instructors teaching the course section.
-    """
+    instructors: Sequence[PyObjectId]
+    """The list of instructors teaching the course section."""
 
     campus: Optional[str] = None
-    """
-    Campus where the course is being taught.
-    """
+    """Campus where the course is being taught."""
 
     max_enroll: Optional[int] = None
-    """
-    The maximum number of students that can enroll in the course section.
-    """
+    """The maximum number of students that can enroll in the course section."""
 
-    enroll: Optional[int | str] = None
-    """
-    The current number of students enrolled in the course section, or a string if the data is not numeric.
-    """
+    enroll: Optional[int] = None
+    """The current number of students enrolled in the course section."""
 
     comments: Optional[str] = None
-    """
-    Additional comments regarding the course section.
-    """
+    """Additional comments regarding the course section."""
 
     schedule: CourseSchedule
-    """
-    The schedule related information about the course section.
-    """
+    """The schedule related information about the course section."""
 
     def __hash__(self) -> int:
         """
@@ -97,16 +69,10 @@ class SectionDB(MongoDBModel):
         """
 
         arbitrary_types_allowed = True
-        """
-        Whether arbitrary types are allowed for field types.
-        """
+        """Whether arbitrary types are allowed for field types."""
 
         alias_generator = to_camel
-        """
-        A function that is used to generate aliases for model fields.
-        """
+        """A function that is used to generate aliases for model fields."""
 
         populate_by_name = True
-        """
-        Whether an aliased field may be populated by its name as given by the model attribute, as well as the alias.
-        """
+        """Whether an aliased field may be populated by its name as given by the model attribute, as well as the alias."""

--- a/ucronmodels/universal/enums/db_views.py
+++ b/ucronmodels/universal/enums/db_views.py
@@ -10,3 +10,8 @@ class DBViews(StrEnum):
     """
     The view for distinct subject codes on the Courses collection.
     """
+
+    COURSE_CLIENT = "CourseClient"
+    """
+    The view for CourseClient.
+    """


### PR DESCRIPTION
### New Models

1. **Section Client**
    - [x]  The `SectionClient` should extend `SectionDB` model.
    - [x]  The type of the instructors field should be changed to `List[InstructorDB]`.
2. **Course Client**
    - [x]  The CourseClient should extend the CourseDB model.
    - [x]  The CourseClient should have an additional field `sections` of type `List[SectionClient]`.

### Enum Changes

- [x]  Update the `DBView` enum to include the new `CourseClient` view.

### Changes to existing models

1. **SectionDB**
    - [x]  The type for the `enroll` field should be changed to `int`.
2. **CourseSchedule**
    - [x]  The type for the `start_date` field should be changed to `Date`.
    - [x]  Add custom serializer for `start_date` field to prevent it from getting serialized to a `string`. This is required for the value to be persisted as a `Date` object to the database.
    - [x]  The type for the `end_date` field should be changed to `Date`.
    - [x]  Add custom serializer for `end_date` field to prevent it from getting serialized to a `string`. This is required for the value to be persisted as a `Date` object to the database.
3. **TimeRange**
    - [x]  Thy type for the `start_time` field should be changed to `time | str`.
    - [x]  Thy type for the `end_time` field should be changed to `time | str`.